### PR TITLE
Document ChatGPT fly shop data source

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
       <ul>
         <li><b>Flows and temperature:</b> Live readings from the USGS Water Services “Instantaneous Values (IV)” API. Some gages report only flow (CFS); temperature is included when the gage has a temp sensor.</li>
         <li><b>Freshness:</b> The colored chip shows how recent the last flow reading is.</li>
-        <li><b>Fly shops:</b> Nearby shop info is looked up from OpenStreetMap data and may be incomplete.</li>
+        <li><b>Fly shops:</b> Local fly-shop info is fetched via ChatGPT prompts and may be incomplete.</li>
       </ul>
       <h3>How rivers are ranked</h3>
       <ul>


### PR DESCRIPTION
## Summary
- Update How it works modal to describe fetching local fly-shop info via ChatGPT prompts instead of OpenStreetMap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979edaaf5483339f11f3fda0f0532d