### PR TITLE
feat: Remove result limits and make filtering more inclusive

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 
   <div class="controls">
     <label>Radius mi <input id="radius" type="number" min="10" max="500" step="10" value="250"></label>
-    <label>Max rivers <input id="limit" type="number" min="5" max="50" step="5" value="25"></label>
+    <label>Max rivers <input id="limit" type="number" min="5" max="500" step="5" value="100"></label>
     <button id="refresh">Refresh</button>
     <span class="small" id="origin"></span>
     <label class="small"><input type="checkbox" id="hasTempOnly"> Has temp only</label>
@@ -404,6 +404,15 @@
       // Southern Sierra (Golden Trout Wilderness area)
       if (lat >= 35.8 && lat <= 36.8 && lon >= -118.8 && lon <= -117.8) return true;
 
+      // Santa Cruz Mountains / Central Coast Ranges
+      if (lat >= 36.5 && lat <= 37.5 && lon >= -122.5 && lon <= -121.5) return true;
+
+      // Northern Coast Ranges (Mendocino/Humboldt area)
+      if (lat >= 38.5 && lat <= 40.5 && lon >= -123.8 && lon <= -122.5) return true;
+
+      // Southern California mountains (San Gabriel, San Bernardino)
+      if (lat >= 34.0 && lat <= 35.0 && lon >= -118.5 && lon <= -116.5) return true;
+
       return false;
     }
 
@@ -418,19 +427,13 @@
       if (EXTRA_EXCLUDE.test(name)) return false;
       if (/\b(at|near)\s+mouth\b/i.test(name)) return false;
 
-      // Smart creek filtering: allow if whitelisted OR in trout zone
+      // More inclusive creek filtering: show all creeks, let scoring handle quality
+      // Only reject creeks with obvious warm-water or problematic indicators
       if (/\bCreek\b/i.test(label)) {
-        // Whitelisted creeks always pass
-        if (TROUT_CREEK_WHITELIST.has(label)) return true;
-
-        // Creeks in known trout zones pass
-        if (inTroutZone(lat, lon)) return true;
-
-        // Creeks with "Trout", "Spring", "Cold", "Snow" in name likely good
-        if (/\b(Trout|Spring|Cold|Snow|Golden)\b/i.test(label)) return true;
-
-        // Otherwise reject
-        return false;
+        // Reject obviously problematic creeks
+        if (/\b(Warm|Hot\s+Spring|Irrigation|Urban|Waste|Sewage)\b/i.test(label)) return false;
+        // Accept all other creeks - scoring will rank them appropriately
+        return true;
       }
 
       // All rivers pass if they made it this far
@@ -938,7 +941,7 @@
 
     async function build(){
       const radius = Number(document.getElementById('radius').value || 250);
-      const limit = Number(document.getElementById('limit').value || 25);
+      const limit = Number(document.getElementById('limit').value || 100);
       const origin = await getOrigin();
       document.getElementById('origin').textContent = `Origin ${origin.lat.toFixed(2)}, ${origin.lon.toFixed(2)}`;
       const bbox = milesToBBox(origin, radius);
@@ -971,13 +974,12 @@
       };
       const chosen = [];
       const seen = new Set();
-      const maxCandidates = Math.max(limit * 3, 150);
+      // Process ALL sites - no artificial limit (user can control via "Max rivers" input)
       for (const s of sites){
         const label = s.label;
         if (seen.has(label)) continue;
         seen.add(label);
         chosen.push({ ...s, parent: forksMap[label] || label });
-        if (chosen.length >= maxCandidates) break;
       }
 
       const ids = chosen.map(s => s.siteCode);


### PR DESCRIPTION
This commit addresses the issue where Santa Cruz and other coastal areas were showing very few rivers despite having many nearby waters.

## Changes Made

### 1. Removed Artificial Candidate Limits
- Removed `maxCandidates = 150` restriction
- Now processes ALL sites that pass filtering
- User controls display via "Max rivers" input only

### 2. Increased Default Display Limits
- Default max rivers: 25 → 100
- Max limit input: 50 → 500
- Users can now see comprehensive lists

### 3. Expanded Geographic Zones
Added three new trout zones to inTroutZone():
- Santa Cruz Mountains / Central Coast Ranges (36.5-37.5°N, 122.5-121.5°W)
- Northern Coast Ranges - Mendocino/Humboldt (38.5-40.5°N, 123.8-122.5°W)
- Southern California mountains - San Gabriel/San Bernardino (34.0-35.0°N, 118.5-116.5°W)

### 4. More Inclusive Creek Filtering
Previous: Only allowed creeks if whitelisted OR in zone OR special name New: Allow ALL creeks except those with obvious problematic indicators
- Reject: "Warm", "Irrigation", "Urban", "Waste", "Sewage"
- Accept: Everything else (let scoring handle quality)

## Impact on Santa Cruz Area

Before:
- Closest river: 140+ miles
- Showing Arizona rivers (Colorado)
- Missing all nearby creeks

After (Expected):
- San Lorenzo River (goes through Santa Cruz)
- Soquel Creek
- Aptos Creek
- Pajaro River
- Salinas River
- Plus all mountain creeks in Santa Cruz Mountains

## Technical Details

The app still fetches real-time data every load:
- Live flow (CFS) from USGS
- Live temperature readings
- Fresh timestamps

Static lists (TROUT_RIVER_WHITELIST, WARM_WATER_LIST, etc.) remain hardcoded but scoring dynamically penalizes based on live temperature data.

🎣 Generated with [Claude Code](https://claude.com/claude-code)